### PR TITLE
Add predefined identifier D_OpenD to identify forked compiler.

### DIFF
--- a/compiler/src/dmd/target.d
+++ b/compiler/src/dmd/target.d
@@ -108,6 +108,7 @@ void addDefaultVersionIdentifiers(const ref Param params, const ref Target tgt)
     VersionCondition.addPredefinedGlobalIdent("LittleEndian");
     VersionCondition.addPredefinedGlobalIdent("D_Version2");
     VersionCondition.addPredefinedGlobalIdent("all");
+    VersionCondition.addPredefinedGlobalIdent("D_OpenD");
 
     addPredefinedGlobalIdentifiers(tgt);
 


### PR DESCRIPTION
As discussed here: https://github.com/orgs/opendlang/discussions/3